### PR TITLE
Support zooming on touch screen devices + enable dragging when zoomed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,11 @@ const zoom3 = new ZoomAnyJs("#zoom3")
 
 Basic options can be set by using data-* attributes on the element you zoom:
 
-- data-max-zoom: Set maximimum zoom. Default: 4000
-- data-min-zoom: Set minimum zoom. Default: 10
+- data-max-zoom: Set maximimum zoom. Integer or "fit". Default: 4000
+- data-min-zoom: Set minimum zoom. Integer or "fit". Default: 10
 - data-bounds: Enable fit to bounding. Default: false
 - data-origin-parent: Use the _offsetParent_ as origin for fitting bounding. Else it uses window. Default: false
+- data-draggable: Enable dragging of the content within the wrapper/container. Default: false
 
 _The default zoom level is 100, which is the original size and represents a scale of 1.0_
 
@@ -130,6 +131,7 @@ All available functions:
 - center(): Moves the image to the center of the window or the offsetParent when using data-origin-parent
 - fitToBounds(): Fits into the bounds when using data-bounds, else it just returns void
 - zoomAt(amplitude: number, pos: {x: number, y: number}): Move to the position by the amplitude. Amplitude > 1 zooms in and amplitude < 1 zooms out
+- zoomToFit(): set the zoom level such that the contents exactly fits within the parent/wrapper
 - addListeners(): Adds the event listeners
 - removeListeners(): Removes the event listeners
 - apply(): Has to be callen to update the view. Without calling it, you cant see any change

--- a/README.md
+++ b/README.md
@@ -141,3 +141,4 @@ All available functions:
 - setZoom(value: number): Sets the zoom
 - getPos(): Returns the position
 - setPos(value: {x: number, y: number}): Sets the position
+- isInteracting(): Return whether the person is currently interacting (zooming / dragging) with the content

--- a/docs/index.html
+++ b/docs/index.html
@@ -182,6 +182,12 @@ const zoom = new ZoomAnyJs()</code></pre>
                     <td>void</td>
                 </tr>
                 <tr>
+                    <td>zoomToFit</td>
+                    <td>Set the zoom level such that the contents exactly fits within the parent/wrapper.</td>
+                    <td>None</td>
+                    <td>void</td>
+                </tr>
+                <tr>
                     <td>addListeners</td>
                     <td>Adds event listeners to the element for handling user interactions.</td>
                     <td>None</td>
@@ -237,6 +243,11 @@ const zoom = new ZoomAnyJs()</code></pre>
                 <tr>
                     <td>data-origin-parent</td>
                     <td>Use the offsetParent as origin for fitting bounding. Else it uses window</td>
+                    <td>false</td>
+                </tr>
+                <tr>
+                    <td>data-draggable</td>
+                    <td>Enable dragging of the content within the wrapper/container</td>
                     <td>false</td>
                 </tr>
                 </tbody>

--- a/docs/index.html
+++ b/docs/index.html
@@ -164,7 +164,7 @@ const zoom = new ZoomAnyJs()</code></pre>
                 <tr>
                     <td>center</td>
                     <td>Centers the element within its container, which can be the window or the element's parent.</td>
-                    <td>None</td>
+                    <td>string ('x' | 'y' | 'xy')</td>
                     <td>void</td>
                 </tr>
                 <tr>
@@ -210,6 +210,15 @@ const zoom = new ZoomAnyJs()</code></pre>
                     <td>Removes all listeners and CSS changes, reverting the element to its initial state.</td>
                     <td>None</td>
                     <td>void</td>
+                </tr>
+                <tr>
+                    <td>isInteracting</td>
+                    <td>
+                        Return whether the person is currently interacting (zooming / dragging) with the content. This
+                        can be used for example to prevent a click action when the user is dragging the content.
+                    </td>
+                    <td>None</td>
+                    <td>boolean</td>
                 </tr>
                 </tbody>
             </table>

--- a/src/zoom-any-js.css
+++ b/src/zoom-any-js.css
@@ -1,6 +1,9 @@
 .zoomAnyJs-zoomElement {
     position: relative;
     transform-origin: top left;
+    touch-action: none;
+    width: fit-content;
+    height: fit-content;
 }
 
 .wrapper {


### PR DESCRIPTION
This pull request contains an addition to ZoomAny.js allowing it to:

- let touch screen users zoom the content, by moving two fingers towards or away from each other
- let users (both touch screen users and mouse users) drag the content when zoomed in, if `data-draggable` is set
- call `zoomToFit()` to automatically zoom out to make the content fit the container size
- use `isInteracting()` to prevent certain actions (e.g. clickable items in the content) when the user is zooming and/or dragging the content

Certain methods have slightly changed to accomplish these goals.

Also note that I changed the `zoomAt()` call to use `clientX` and `clientY` instead of `pageX` and `pageY` to avoid incorrect zooming when the page is scrolled down (not at the top).

The implementation regarding zooming on touch screen devices was inspired by: https://github.com/mdn/dom-examples/blob/main/pointerevents/Pinch_zoom_gestures.html